### PR TITLE
Fix link to Bungie blog post

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ In late 2011, Aleph One began distributing Marathon game content bundled with Al
 
 [1]: http://trilogyrelease.bungie.org/
 [2]: http://infinitysource.bungie.org/
-[3]: http://halo.bungie.net/news/content.aspx?cid=31991
+[3]: https://web.archive.org/web/20141013213318/http://halo.bungie.net/News/content.aspx?cid=31991
 
 
 


### PR DESCRIPTION
[halo.bungie.net was taken offline on 2021-02-09][1], so I replaced the blog post link with a copy from the Wayback Machine.

[1]: https://www.bungie.net/en/Explore/Detail/News/50006